### PR TITLE
[INFRA] install composer v1 as composer1 for Magento2

### DIFF
--- a/src/7.0/Dockerfile
+++ b/src/7.0/Dockerfile
@@ -28,17 +28,17 @@ RUN set -xe; \
     /usr/local/bin/docker-php-source-prepare; \
     mkdir -p "${PHP_INI_DIR}/conf.d"; \
     docker-php-source extract; \
-	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
-	debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
-	if [[ ! -d "/usr/include/curl" ]]; then \
-	    ln -sT "/usr/include/${debMultiarch}/curl" /usr/local/include/curl; \
-	fi; \
+    gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
+    debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
+    if [[ ! -d "/usr/include/curl" ]]; then \
+        ln -sT "/usr/include/${debMultiarch}/curl" /usr/local/include/curl; \
+    fi; \
     cd /usr/src/php; \
-	export \
-		CFLAGS="$PHP_CFLAGS" \
-		CPPFLAGS="$PHP_CPPFLAGS" \
-		LDFLAGS="$PHP_LDFLAGS" \
-	; \
+    export \
+        CFLAGS="$PHP_CFLAGS" \
+        CPPFLAGS="$PHP_CPPFLAGS" \
+        LDFLAGS="$PHP_LDFLAGS" \
+    ; \
     ./configure \
         --build="$gnuArch" \
         --with-config-file-path="$PHP_INI_DIR" \
@@ -130,7 +130,7 @@ RUN set -xe; \
     ################################################
     mkdir -p /tmp/ioncube; \
     cd /tmp/ioncube; \
-	docker-package-download -o ioncube.tar.gz -s https://downloads.ioncube.com/loader_downloads/ioncube_loaders_lin_x86-64.tar.gz; \
+    docker-package-download -o ioncube.tar.gz -s https://downloads.ioncube.com/loader_downloads/ioncube_loaders_lin_x86-64.tar.gz; \
     tar --strip 1 -xzf ioncube.tar.gz; \
     cp "ioncube_loader_lin_$(php -r \@phpinfo\(\)\; | grep 'PHP Version' -m 1 | grep -oE '([0-9\.]+)' | cut -d. -f1,2).so" "$(/usr/local/bin/php-config --extension-dir)/ioncube.so"; \
     ls -lisah "$(/usr/local/bin/php-config --extension-dir)/ioncube.so"; \
@@ -139,7 +139,7 @@ RUN set -xe; \
     ################################################
     mkdir -p /tmp/newrelic; \
     cd /tmp/newrelic; \
-	docker-package-download -o newrelic.tar.gz -s https://download.newrelic.com/php_agent/archive/${PHP_EXT_NEWRELIC_VERSION:-8.5.0.235}/newrelic-php5-${PHP_EXT_NEWRELIC_VERSION:-8.5.0.235}-linux.tar.gz; \
+    docker-package-download -o newrelic.tar.gz -s https://download.newrelic.com/php_agent/archive/${PHP_EXT_NEWRELIC_VERSION:-8.5.0.235}/newrelic-php5-${PHP_EXT_NEWRELIC_VERSION:-8.5.0.235}-linux.tar.gz; \
     tar --strip 1 -xzf newrelic.tar.gz; \
     cp "agent/$(uname -m | grep -oE '(x?[0-9]+)' | head -1)/newrelic-$(phpize -v | grep Zend\ M | grep -oE '([0-9]+)').so" "$(/usr/local/bin/php-config --extension-dir)/newrelic.so"; \
     ls -lisah "$(/usr/local/bin/php-config --extension-dir)/newrelic.so"; \

--- a/src/7.1/src/Dockerfile
+++ b/src/7.1/src/Dockerfile
@@ -33,17 +33,17 @@ RUN set -xe; \
     chmod +x /usr/local/bin/mhsendmail; \
     mkdir -p "${PHP_INI_DIR}/conf.d"; \
     docker-php-source extract; \
-	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
-	debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
-	if [[ ! -d "/usr/include/curl" ]]; then \
-	    ln -sT "/usr/include/${debMultiarch}/curl" /usr/local/include/curl; \
-	fi; \
+    gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
+    debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
+    if [[ ! -d "/usr/include/curl" ]]; then \
+        ln -sT "/usr/include/${debMultiarch}/curl" /usr/local/include/curl; \
+    fi; \
     cd /usr/src/php; \
-	export \
-		CFLAGS="$PHP_CFLAGS" \
-		CPPFLAGS="$PHP_CPPFLAGS" \
-		LDFLAGS="$PHP_LDFLAGS" \
-	; \
+        export \
+        CFLAGS="$PHP_CFLAGS" \
+        CPPFLAGS="$PHP_CPPFLAGS" \
+        LDFLAGS="$PHP_LDFLAGS" \
+    ; \
     ./configure \
         --build="$gnuArch" \
         --with-config-file-path="$PHP_INI_DIR" \
@@ -128,7 +128,7 @@ RUN set -xe; \
     ################################################
     mkdir -p /tmp/newrelic; \
     cd /tmp/newrelic; \
-	docker-package-download -o newrelic.tar.gz -s "https://download.newrelic.com/php_agent/archive/${PHP_EXT_NEWRELIC_VERSION}/newrelic-php5-${PHP_EXT_NEWRELIC_VERSION}-linux.tar.gz"; \
+    docker-package-download -o newrelic.tar.gz -s "https://download.newrelic.com/php_agent/archive/${PHP_EXT_NEWRELIC_VERSION}/newrelic-php5-${PHP_EXT_NEWRELIC_VERSION}-linux.tar.gz"; \
     tar --strip 1 -xzf newrelic.tar.gz; \
     cp "agent/$(uname -m | grep -oE '(x?[0-9]+)' | head -1)/newrelic-$(phpize -v | grep Zend\ M | grep -oE '([0-9]+)').so" "$(/usr/local/bin/php-config --extension-dir)/newrelic.so"; \
     ls -lisah "$(/usr/local/bin/php-config --extension-dir)/newrelic.so"; \
@@ -137,7 +137,7 @@ RUN set -xe; \
     ################################################
     mkdir -p /tmp/tideways; \
     cd /tmp/tideways; \
- 	docker-package-download -o tideways.tar.gz -s https://s3-eu-west-1.amazonaws.com/tideways/extension/${PHP_EXT_TIDEWAYS_VERSION}/tideways-php-${PHP_EXT_TIDEWAYS_VERSION}-x86_64.tar.gz; \
+    docker-package-download -o tideways.tar.gz -s https://s3-eu-west-1.amazonaws.com/tideways/extension/${PHP_EXT_TIDEWAYS_VERSION}/tideways-php-${PHP_EXT_TIDEWAYS_VERSION}-x86_64.tar.gz; \
     tar --strip 2 -xzf tideways.tar.gz; \
     ls -lisah; \
     cp "tideways-php-$(php -r \@phpinfo\(\)\; | grep 'PHP Version' -m 1 | grep -oE '([0-9\.]+)' | cut -d. -f1,2).so" "$(/usr/local/bin/php-config --extension-dir)/tideways.so"; \
@@ -149,6 +149,11 @@ RUN set -xe; \
     COMPOSER_DOWNLOAD_LATEST=$(curl -s curl -s https://api.github.com/repos/composer/composer/releases/latest | grep "browser_download_url.*phar" | cut -d '"' -f 4) ; \
     docker-package-download -o /usr/local/bin/composer ${COMPOSER_DOWNLOAD_LATEST}; \
     chmod +x /usr/local/bin/composer; \
+    ################################################
+    ## install Composer 1 for Magento 2
+    ################################################
+    docker-package-download -o /usr/local/bin/composer1 https://getcomposer.org/composer-1.phar; \
+    chmod +x /usr/local/bin/composer1; \
     ################################################
     ## install magerun
     ################################################

--- a/src/7.2/src/Dockerfile
+++ b/src/7.2/src/Dockerfile
@@ -39,17 +39,17 @@ RUN set -xe; \
     make install PREFIX=/usr; \
     mkdir -p "${PHP_INI_DIR}/conf.d"; \
     docker-php-source extract; \
-	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
-	debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
-	if [[ ! -d "/usr/include/curl" ]]; then \
-	    ln -sT "/usr/include/${debMultiarch}/curl" /usr/local/include/curl; \
-	fi; \
+    gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
+    debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
+    if [[ ! -d "/usr/include/curl" ]]; then \
+        ln -sT "/usr/include/${debMultiarch}/curl" /usr/local/include/curl; \
+    fi; \
     cd /usr/src/php; \
-	export \
-		CFLAGS="$PHP_CFLAGS" \
-		CPPFLAGS="$PHP_CPPFLAGS" \
-		LDFLAGS="$PHP_LDFLAGS" \
-	; \
+    export \
+        CFLAGS="$PHP_CFLAGS" \
+        CPPFLAGS="$PHP_CPPFLAGS" \
+        LDFLAGS="$PHP_LDFLAGS" \
+    ; \
     ./configure \
         --build="$gnuArch" \
         --with-config-file-path="$PHP_INI_DIR" \
@@ -137,7 +137,7 @@ RUN set -xe; \
     ################################################
     mkdir -p /tmp/newrelic; \
     cd /tmp/newrelic; \
-	docker-package-download -o newrelic.tar.gz -s "https://download.newrelic.com/php_agent/archive/${PHP_EXT_NEWRELIC_VERSION}/newrelic-php5-${PHP_EXT_NEWRELIC_VERSION}-linux.tar.gz"; \
+    docker-package-download -o newrelic.tar.gz -s "https://download.newrelic.com/php_agent/archive/${PHP_EXT_NEWRELIC_VERSION}/newrelic-php5-${PHP_EXT_NEWRELIC_VERSION}-linux.tar.gz"; \
     tar --strip 1 -xzf newrelic.tar.gz; \
     cp "agent/$(uname -m | grep -oE '(x?[0-9]+)' | head -1)/newrelic-$(phpize -v | grep Zend\ M | grep -oE '([0-9]+)').so" "$(/usr/local/bin/php-config --extension-dir)/newrelic.so"; \
     ls -lisah "$(/usr/local/bin/php-config --extension-dir)/newrelic.so"; \
@@ -146,7 +146,7 @@ RUN set -xe; \
     ################################################
     mkdir -p /tmp/tideways; \
     cd /tmp/tideways; \
- 	docker-package-download -o tideways.tar.gz -s https://s3-eu-west-1.amazonaws.com/tideways/extension/${PHP_EXT_TIDEWAYS_VERSION}/tideways-php-${PHP_EXT_TIDEWAYS_VERSION}-x86_64.tar.gz; \
+    docker-package-download -o tideways.tar.gz -s https://s3-eu-west-1.amazonaws.com/tideways/extension/${PHP_EXT_TIDEWAYS_VERSION}/tideways-php-${PHP_EXT_TIDEWAYS_VERSION}-x86_64.tar.gz; \
     tar --strip 2 -xzf tideways.tar.gz; \
     ls -lisah; \
     cp "tideways-php-$(php -r \@phpinfo\(\)\; | grep 'PHP Version' -m 1 | grep -oE '([0-9\.]+)' | cut -d. -f1,2).so" "$(/usr/local/bin/php-config --extension-dir)/tideways.so"; \
@@ -158,6 +158,11 @@ RUN set -xe; \
     COMPOSER_DOWNLOAD_LATEST=$(curl -s curl -s https://api.github.com/repos/composer/composer/releases/latest | grep "browser_download_url.*phar" | cut -d '"' -f 4) ; \
     docker-package-download -o /usr/local/bin/composer ${COMPOSER_DOWNLOAD_LATEST}; \
     chmod +x /usr/local/bin/composer; \
+    ################################################
+    ## install Composer 1 for Magento 2
+    ################################################
+    docker-package-download -o /usr/local/bin/composer1 https://getcomposer.org/composer-1.phar; \
+    chmod +x /usr/local/bin/composer1; \
     ################################################
     ## install magerun
     ################################################

--- a/src/7.3/src/Dockerfile
+++ b/src/7.3/src/Dockerfile
@@ -40,17 +40,17 @@ RUN set -xe; \
     make install PREFIX=/usr; \
     mkdir -p "${PHP_INI_DIR}/conf.d"; \
     docker-php-source extract; \
-	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
-	debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
-	if [[ ! -d "/usr/include/curl" ]]; then \
-	    ln -sT "/usr/include/${debMultiarch}/curl" /usr/local/include/curl; \
-	fi; \
+    gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
+    debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
+    if [[ ! -d "/usr/include/curl" ]]; then \
+        ln -sT "/usr/include/${debMultiarch}/curl" /usr/local/include/curl; \
+    fi; \
     cd /usr/src/php; \
-	export \
-		CFLAGS="$PHP_CFLAGS" \
-		CPPFLAGS="$PHP_CPPFLAGS" \
-		LDFLAGS="$PHP_LDFLAGS" \
-	; \
+    export \
+        CFLAGS="$PHP_CFLAGS" \
+        CPPFLAGS="$PHP_CPPFLAGS" \
+        LDFLAGS="$PHP_LDFLAGS" \
+    ; \
     ./configure \
         --build="$gnuArch" \
         --with-config-file-path="$PHP_INI_DIR" \
@@ -136,7 +136,7 @@ RUN set -xe; \
     ################################################
     mkdir -p /tmp/newrelic; \
     cd /tmp/newrelic; \
-	docker-package-download -o newrelic.tar.gz -s "https://download.newrelic.com/php_agent/archive/${PHP_EXT_NEWRELIC_VERSION}/newrelic-php5-${PHP_EXT_NEWRELIC_VERSION}-linux.tar.gz"; \
+    docker-package-download -o newrelic.tar.gz -s "https://download.newrelic.com/php_agent/archive/${PHP_EXT_NEWRELIC_VERSION}/newrelic-php5-${PHP_EXT_NEWRELIC_VERSION}-linux.tar.gz"; \
     tar --strip 1 -xzf newrelic.tar.gz; \
     cp "agent/$(uname -m | grep -oE '(x?[0-9]+)' | head -1)/newrelic-$(phpize -v | grep Zend\ M | grep -oE '([0-9]+)').so" "$(/usr/local/bin/php-config --extension-dir)/newrelic.so"; \
     ls -lisah "$(/usr/local/bin/php-config --extension-dir)/newrelic.so"; \
@@ -145,7 +145,7 @@ RUN set -xe; \
     ################################################
     mkdir -p /tmp/tideways; \
     cd /tmp/tideways; \
- 	docker-package-download -o tideways.tar.gz -s https://s3-eu-west-1.amazonaws.com/tideways/extension/${PHP_EXT_TIDEWAYS_VERSION}/tideways-php-${PHP_EXT_TIDEWAYS_VERSION}-x86_64.tar.gz; \
+    docker-package-download -o tideways.tar.gz -s https://s3-eu-west-1.amazonaws.com/tideways/extension/${PHP_EXT_TIDEWAYS_VERSION}/tideways-php-${PHP_EXT_TIDEWAYS_VERSION}-x86_64.tar.gz; \
     tar --strip 2 -xzf tideways.tar.gz; \
     ls -lisah; \
     cp "tideways-php-$(php -r \@phpinfo\(\)\; | grep 'PHP Version' -m 1 | grep -oE '([0-9\.]+)' | cut -d. -f1,2).so" "$(/usr/local/bin/php-config --extension-dir)/tideways.so"; \
@@ -157,6 +157,11 @@ RUN set -xe; \
     COMPOSER_DOWNLOAD_LATEST=$(curl -s curl -s https://api.github.com/repos/composer/composer/releases/latest | grep "browser_download_url.*phar" | cut -d '"' -f 4) ; \
     docker-package-download -o /usr/local/bin/composer ${COMPOSER_DOWNLOAD_LATEST}; \
     chmod +x /usr/local/bin/composer; \
+    ################################################
+    ## install Composer 1 for Magento 2
+    ################################################
+    docker-package-download -o /usr/local/bin/composer1 https://getcomposer.org/composer-1.phar; \
+    chmod +x /usr/local/bin/composer1; \
     ################################################
     ## install magerun
     ################################################

--- a/src/7.4/src/Dockerfile
+++ b/src/7.4/src/Dockerfile
@@ -39,17 +39,17 @@ RUN set -xe; \
     make install PREFIX=/usr; \
     mkdir -p "${PHP_INI_DIR}/conf.d"; \
     docker-php-source extract; \
-	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
-	debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
-	if [[ ! -d "/usr/include/curl" ]]; then \
-	    ln -sT "/usr/include/${debMultiarch}/curl" /usr/local/include/curl; \
-	fi; \
+    gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
+    debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
+    if [[ ! -d "/usr/include/curl" ]]; then \
+        ln -sT "/usr/include/${debMultiarch}/curl" /usr/local/include/curl; \
+    fi; \
     cd /usr/src/php; \
-	export \
-		CFLAGS="$PHP_CFLAGS" \
-		CPPFLAGS="$PHP_CPPFLAGS" \
-		LDFLAGS="$PHP_LDFLAGS" \
-	; \
+    export \
+        CFLAGS="$PHP_CFLAGS" \
+        CPPFLAGS="$PHP_CPPFLAGS" \
+        LDFLAGS="$PHP_LDFLAGS" \
+    ; \
     ./configure \
         --build="$gnuArch" \
         --with-config-file-path="$PHP_INI_DIR" \
@@ -135,7 +135,7 @@ RUN set -xe; \
     ################################################
     mkdir -p /tmp/newrelic; \
     cd /tmp/newrelic; \
-	docker-package-download -o newrelic.tar.gz -s "https://download.newrelic.com/php_agent/archive/${PHP_EXT_NEWRELIC_VERSION}/newrelic-php5-${PHP_EXT_NEWRELIC_VERSION}-linux.tar.gz"; \
+    docker-package-download -o newrelic.tar.gz -s "https://download.newrelic.com/php_agent/archive/${PHP_EXT_NEWRELIC_VERSION}/newrelic-php5-${PHP_EXT_NEWRELIC_VERSION}-linux.tar.gz"; \
     tar --strip 1 -xzf newrelic.tar.gz; \
     cp "agent/$(uname -m | grep -oE '(x?[0-9]+)' | head -1)/newrelic-$(phpize -v | grep Zend\ M | grep -oE '([0-9]+)').so" "$(/usr/local/bin/php-config --extension-dir)/newrelic.so"; \
     ls -lisah "$(/usr/local/bin/php-config --extension-dir)/newrelic.so"; \
@@ -144,7 +144,7 @@ RUN set -xe; \
     ################################################
     mkdir -p /tmp/tideways; \
     cd /tmp/tideways; \
- 	docker-package-download -o tideways.tar.gz -s https://s3-eu-west-1.amazonaws.com/tideways/extension/${PHP_EXT_TIDEWAYS_VERSION}/tideways-php-${PHP_EXT_TIDEWAYS_VERSION}-x86_64.tar.gz; \
+    docker-package-download -o tideways.tar.gz -s https://s3-eu-west-1.amazonaws.com/tideways/extension/${PHP_EXT_TIDEWAYS_VERSION}/tideways-php-${PHP_EXT_TIDEWAYS_VERSION}-x86_64.tar.gz; \
     tar --strip 2 -xzf tideways.tar.gz; \
     ls -lisah; \
     cp "tideways-php-$(php -r \@phpinfo\(\)\; | grep 'PHP Version' -m 1 | grep -oE '([0-9\.]+)' | cut -d. -f1,2).so" "$(/usr/local/bin/php-config --extension-dir)/tideways.so"; \
@@ -156,6 +156,11 @@ RUN set -xe; \
     COMPOSER_DOWNLOAD_LATEST=$(curl -s curl -s https://api.github.com/repos/composer/composer/releases/latest | grep "browser_download_url.*phar" | cut -d '"' -f 4) ; \
     docker-package-download -o /usr/local/bin/composer ${COMPOSER_DOWNLOAD_LATEST}; \
     chmod +x /usr/local/bin/composer; \
+    ################################################
+    ## install Composer 1 for Magento 2
+    ################################################
+    docker-package-download -o /usr/local/bin/composer1 https://getcomposer.org/composer-1.phar; \
+    chmod +x /usr/local/bin/composer1; \
     ################################################
     ## install magerun
     ################################################


### PR DESCRIPTION
- adds composer v1 latest as `composer1` in parallel to `composer` to enable working with Magento2 after composer v2 was promoted as the default.